### PR TITLE
keep expressionMap for script expressions

### DIFF
--- a/lib/html_parser/decoder.js
+++ b/lib/html_parser/decoder.js
@@ -64,8 +64,6 @@ const decodeExpressions = (expressionMap) => {
         if (/eexs\d+eexs/.test(part)) {
           const decodedPart = part.replace(/eexs\d+eexs/, (match) => {
             const expression = expressionMap.get(match);
-            expressionMap.delete(match);
-
             return expression.print;
           });
 


### PR DESCRIPTION
I had some issues with Elixir expressions inside of script tags. This was the smallest file I could get that reproduced the bug:

```eelixir
<script type="text/javascript">
  console.log("<%= Routes.invite_path(@conn, :create_request) %>", {
    opts: {},
  })
</script>
```

When running as is, prettier would replace the Elixir expression inside of the double quotes with `eexs1eexs`

I don't know the library well enough to know if there are any potential negative ramifications of this change, so I'm happy to make any changes I need to in order to get this through.

And thanks again for the plugin! This has made working with eex so much nicer 😄