### PR TITLE
Fix eexMultilineNoParens option

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -28,7 +28,7 @@ const formatEex = (tokens, options = {}) => {
     const { eexMultilineLineLength, eexMultilineNoParens } = options;
     let eexFormatterOptions = `--line-length=${eexMultilineLineLength}`;
     if (eexMultilineNoParens.length) {
-      eexFormatterOptions = eexFormatterOptions.concat(' --no-parens=${eexFormatterOptions.join(", ")}');
+      eexFormatterOptions = eexFormatterOptions.concat(` --no-parens=${eexMultilineNoParens.join(",")}`);
     }
 
     const binPath = path.join(__dirname, '..', 'prettier_eex_formatter_release');

--- a/tests_elixir/.prettierrc.js
+++ b/tests_elixir/.prettierrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    eexMultilineNoParens: [
+        "select"
+    ]
+};

--- a/tests_elixir/formatted_views/multiline.html.eex
+++ b/tests_elixir/formatted_views/multiline.html.eex
@@ -4,3 +4,7 @@
     c: "e"
   )
 %>
+
+<%= select f, :name, [
+      {:option, :value}
+    ] %>


### PR DESCRIPTION
If you try to add this option to .prettierrc.js then it blows up:

```
formatted_views/multiline.html.eex/bin/sh: --no-parens=${eexFormatterOptions.join(", ")}: bad substitution

[error] formatted_views/multiline.html.eex: Error: Command failed: /Users/bartosz/Projects/prettier-plugin-eex/prettier_eex_formatter_release CiAgbGlua190bygKICAgIGE6ICJiIiwKICAgIGM6ICJlIgogICk= IHNlbGVjdCBmLCA6bmFtZSwgWwogICAgICB7Om9wdGlvbiwgOnZhbHVlfQogICAgXQ== --line-length=98 --no-parens=${eexFormatterOptions.join(", ")}
[error] /bin/sh: --no-parens=${eexFormatterOptions.join(", ")}: bad substitution
[error] 
[error]     at checkExecSyncError (child_process.js:635:11)
[error]     at execSync (child_process.js:671:15)
[error]     at formatEex (/Users/bartosz/Projects/prettier-plugin-eex/lib/formatter.js:35:5)
[error]     at Object.print (/Users/bartosz/Projects/prettier-plugin-eex/lib/printers.js:23:27)
[error]     at callPluginPrintFunction (/Users/bartosz/Projects/prettier-plugin-eex/node_modules/prettier/index.js:14718:18)
[error]     at /Users/bartosz/Projects/prettier-plugin-eex/node_modules/prettier/index.js:14649:47
[error]     at Object.printComments (/Users/bartosz/Projects/prettier-plugin-eex/node_modules/prettier/index.js:14305:19)
[error]     at printGenerically (/Users/bartosz/Projects/prettier-plugin-eex/node_modules/prettier/index.js:14649:22)
[error]     at printAstToDoc (/Users/bartosz/Projects/prettier-plugin-eex/node_modules/prettier/index.js:14659:13)
[error]     at coreFormat (/Users/bartosz/Projects/prettier-plugin-eex/node_modules/prettier/index.js:14910:15)
```

This PR fixes the issue and add a small test case for this (just in elixir E2E, couldn't to find any test cases in JS for this...)